### PR TITLE
Add Constant Gates to BLIF parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Eric Hennenfent <eric.hennenfent@trailofbits.com>"]
 readme = "README.md"
 keywords = ["cryptography", "zero-knowledge", "circuits", "arithmetic-circuits"]
 categories = ["cryptography"]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The BLIF parser will automatically emit `Const` gates for the `$true` and `$false` symbols if they appear in BLIF files. 