### PR TITLE
IR0 compilation

### DIFF
--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -8,6 +8,7 @@ mod sieve;
 
 pub use bristol::BristolFashion;
 pub use json::bool_circuit_to_json;
+pub use sieve::IR0;
 pub use sieve::IR1;
 
 /// The core export trait.


### PR DESCRIPTION
this is a hack for the time being.

- three file format (`.wit`, `.rel`, `.ins`) breaks underlying `Export` trait assuming one-file output. have this writing pulled out to the CLI in the SIEVE repo.
- the spec is quite close to the extant IR1 compilation and duplicates a most of its body.